### PR TITLE
allow users to purge their own data and PSR-12 cleanup

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -424,7 +424,7 @@ class helper_plugin_attribute extends DokuWiki_Plugin
 
     /**
      * Deletes all attribute data for a specified namespace for a user. Only
-     * useable by an admin.
+     * usable the user themselves or an admin.
      *
      * @param string $namespace
      * @param string $user
@@ -437,9 +437,7 @@ class helper_plugin_attribute extends DokuWiki_Plugin
             return false;
         }
 
-        // Ensure this user purges their own data or is an admin.
-        global $INFO;
-        if(!$INFO['isadmin']) {
+        if ($this->validateUser($user) === null) {
             return false;
         }
 

--- a/helper.php
+++ b/helper.php
@@ -259,7 +259,7 @@ class helper_plugin_attribute extends DokuWiki_Plugin
         // Get usernames from files
         $users = array_map(
             function ($x) use ($key) {
-                return substr($x, strlen($key));
+                return rawurldecode(substr($x, strlen($key)));
             },
             $files
         );

--- a/helper.php
+++ b/helper.php
@@ -192,7 +192,7 @@ class helper_plugin_attribute extends DokuWiki_Plugin
         }
 
         // Set a reasonable default if either unserialize failed.
-        if ($preserial == false || $unseriala === false) {
+        if ($preserial == false || $unserial === false) {
             $data = array();
         }
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 ﻿base   attribute
-author Michael Wilmes
-email  mwilmes@avc.edu
-date   2018-06-28
+author CosmoCode & Michael Wilmes
+email  dokuwiki@cosmocode.de
+date   2022-04-07
 name   Attribute Plugin
 desc   Arbitrary attribute definition and storage for user associated data.
 url    https://www.dokuwiki.org/plugin:attribute


### PR DESCRIPTION
This is part of the efforts described in wilminator/dokuwiki-plugin-twofactor#28 The PR cleans up the code to the PSR-12 coding standard, but more importantly enables the `purge()` action for non-admin users (so a user can purge their own data).